### PR TITLE
Include arrondissements municipaux

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,12 @@ Exemple d’utilisation basique :
 DecoupageAdministratif::Region.all
 
 # Trouver une commune par code INSEE
-# Une commune a un commune_type qui peut être `commune-actuelle`, `commune-deleguee` (anciennes communes) ou `commune-associee` (anciennes communes avec un statut spécial)
+# Une commune a un commune_type qui peut être :commune_actuelle, :commune_deleguee (anciennes communes), :commune_associee (anciennes communes avec un statut spécial) ou :arrondissement_municipal (arrondissements de Paris, Lyon, Marseille)
 commune = DecoupageAdministratif::Commune.find('75056')
 puts commune.nom # => "Paris"
+
+# Lister toutes les communes actuelles (communes actuelles + arrondissements municipaux)
+DecoupageAdministratif::Commune.actuelles
 
 # Lister les départements d'une région
 DecoupageAdministratif::Region.find('84').departements
@@ -224,9 +227,12 @@ Basic usage example:
 DecoupageAdministratif::Region.all
 
 # Find a municipality by INSEE code
-# A municipality has a `commune_type` which can be :commune_actuelle (current municipalities), :commune_deleguee (former municipalities), or :commune_associee (former municipalities with a special status)
+# A municipality has a `commune_type` which can be :commune_actuelle (current municipalities), :commune_deleguee (former municipalities), :commune_associee (former municipalities with a special status), or :arrondissement_municipal (municipal districts of Paris, Lyon, Marseille)
 commune = DecoupageAdministratif::Commune.find('75056')
 puts commune.nom # => "Paris"
+
+# List all current municipalities (current communes + municipal districts)
+DecoupageAdministratif::Commune.actuelles
 
 # List departments of a region
 DecoupageAdministratif::Region.find('84').departements

--- a/lib/decoupage_administratif/commune.rb
+++ b/lib/decoupage_administratif/commune.rb
@@ -20,6 +20,7 @@ module DecoupageAdministratif
     #     - :commune_actuelle: Standard current commune
     #     - :commune_deleguee: Delegated commune
     #     - :commune_associee: Associated commune
+    #     - :arrondissement_municipal: Municipal district (Paris, Lyon, Marseille)
     #   @note Default value is :commune_actuelle
     attr_reader :code, :nom, :zone, :region_code, :departement_code, :commune_type
 
@@ -54,9 +55,9 @@ module DecoupageAdministratif
       end
     end
 
-    # @return [Array<Commune>] a collection of all communes _actuelles_
+    # @return [Array<Commune>] a collection of all communes _actuelles_ and municipal districts
     def self.actuelles
-      @actuelles ||= where(commune_type: :commune_actuelle)
+      @actuelles ||= where(commune_type: %i[commune_actuelle arrondissement_municipal])
     end
 
     # @raise [NotFoundError] if no region is found for the code

--- a/sig/decoupage_administratif/commune.rbs
+++ b/sig/decoupage_administratif/commune.rbs
@@ -8,7 +8,7 @@ module DecoupageAdministratif
     attr_reader zone: String
     attr_reader region_code: String
     attr_reader departement_code: String
-    attr_reader commune_type: String
+    attr_reader commune_type: Symbol
 
     def initialize: (
         code: String,
@@ -21,7 +21,7 @@ module DecoupageAdministratif
 
     def self.all: () -> Array[Commune]
 
-    def self.communes_actuelles: () -> Array[Commune]
+    def self.actuelles: () -> Array[Commune]
 
     def region: () -> Region
 

--- a/spec/commune_spec.rb
+++ b/spec/commune_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe DecoupageAdministratif::Commune do
     let(:model) { 'communes' }
 
     it "Returns all communes" do
-      expect(subject.size).to eq(16)
+      expect(subject.size).to eq(18)
       expect(subject.first).to have_attributes(
         code: "72180",
         nom: "Mamers",
@@ -27,19 +27,18 @@ RSpec.describe DecoupageAdministratif::Commune do
     end
   end
 
-  describe '#communes_actuelles' do
+  describe '#actuelles' do
     subject { described_class.actuelles }
 
     let(:model) { 'communes' }
 
-    it "Returns all communes actuelles" do
-      expect(subject.size).to eq(14)
-      expect(subject.last).to have_attributes(
-        code: "01042",
-        nom: "Bey",
-        zone: "metro",
-        region_code: "84",
-        departement_code: "01"
+    it "Returns all communes actuelles and municipal districts" do
+      expect(subject.size).to eq(16)
+      expect(subject.map(&:commune_type)).to include(:commune_actuelle, :arrondissement_municipal)
+      expect(subject.find { |c| c.code == "75101" }).to have_attributes(
+        code: "75101",
+        nom: "Paris 1er Arrondissement",
+        commune_type: :arrondissement_municipal
       )
     end
   end

--- a/spec/fixtures/communes.json
+++ b/spec/fixtures/communes.json
@@ -234,5 +234,31 @@
     "arrondissement": "011",
     "departement": "01",
     "region": "84"
+  },
+  {
+    "code": "75101",
+    "nom": "Paris 1er Arrondissement",
+    "typeLiaison": 0,
+    "zone": "metro",
+    "type": "arrondissement-municipal",
+    "commune": "75056",
+    "arrondissement": "751",
+    "departement": "75",
+    "region": "11",
+    "codesPostaux": ["75001"],
+    "population": 15919
+  },
+  {
+    "code": "75102",
+    "nom": "Paris 2e Arrondissement",
+    "typeLiaison": 0,
+    "zone": "metro",
+    "type": "arrondissement-municipal",
+    "commune": "75056",
+    "arrondissement": "751",
+    "departement": "75",
+    "region": "11",
+    "codesPostaux": ["75002"],
+    "population": 21119
   }
 ]


### PR DESCRIPTION
## Description

  Ajoute le support des arrondissements
  municipaux (Paris, Lyon, Marseille) dans
  `Commune.actuelles`.

  ## Changements

  - **Commune.actuelles** : Retourne
  maintenant `:commune_actuelle` +
  `:arrondissement_municipal`

  ## Exemple

  ```ruby
  # Retourne les communes actuelles + arrondissements municipaux
  DecoupageAdministratif::Commune.actuelles
  ```
